### PR TITLE
Fix Ground Control info.plist

### DIFF
--- a/Ground Control/Ground-Control.roboFontExt/info.plist
+++ b/Ground Control/Ground-Control.roboFontExt/info.plist
@@ -30,8 +30,8 @@
 	<key>version</key>
 	<string>1.5</string>
 	<key>repository</key>
-	<string>loicsander/Robofont-scripts/Ground Control</string>
+	<string>loicsander/Robofont-scripts</string>
 	<key>extensionPath</key>
-	<string>Ground-Control.roboFontExt</string>
+	<string>Ground Control/Ground-Control.roboFontExt</string>
 </dict>
 </plist>


### PR DESCRIPTION
The `repository` key should be only your username and the name of the repository (`loicsander/Robofont-scripts`). The sub-folder that the extension is in can be added under `extensionPath`. I'll make this more clear in the Mechanic README.