### PR TITLE
Guard against missing italicSlantOffset

### DIFF
--- a/Glyphs/build-derivatives.py
+++ b/Glyphs/build-derivatives.py
@@ -201,10 +201,13 @@ class DerivativeGlyphsBuilder:
     def collectFontData(self, font):
 
         italicAngle = font.info.italicAngle
-        italicSlantOffset = font.lib['com.typemytype.robofont.italicSlantOffset']
-
         if italicAngle is None: italicAngle = 0
-        if italicSlantOffset is None: italicSlantOffset = 0
+
+        if font.lib.has_key('com.typemytype.robofont.italicSlantOffset'):
+            italicSlantOffset = font.lib['com.typemytype.robofont.italicSlantOffset']
+            if italicSlantOffset is None: italicSlantOffset = 0
+        else:
+            italicSlantOffset = 0
 
         self.tempFont = RFont(showUI=False)
 


### PR DESCRIPTION
When using vfb2ufo (in my instance build 2015-01-23), the ufo does not
contain com.typemytype.robofont.italicSlantOffset, so the script will
fail. Therefore, add a small guard to cope with this situation.