### PR TITLE
Fix: InterpolationMatrix glyph preview for fonts with UPM > 1000

### DIFF
--- a/Interpolation Matrix/InterpolationMatrix.roboFontExt/lib/interpolation-matrix-mutatorMath.py
+++ b/Interpolation Matrix/InterpolationMatrix.roboFontExt/lib/interpolation-matrix-mutatorMath.py
@@ -69,6 +69,9 @@ def makePreviewGlyph(glyph, fixedWidth=True):
                 previewGlyph.scale((.75, .75), (previewGlyph.width/2, 0))
                 previewGlyph.move((0, -50))
 
+            scaleFactor = 1000.0 / font.info.unitsPerEm
+            previewGlyph.scale((scaleFactor, scaleFactor), (previewGlyph.width/2, 0))
+
             previewGlyph.name = glyph.name
 
         return previewGlyph


### PR DESCRIPTION
Problem: glyphs with more than 1000 UPM were cropped in the preview
Solution: scale preview accordingly